### PR TITLE
Auth login email

### DIFF
--- a/decide/authentication/serializers.py
+++ b/decide/authentication/serializers.py
@@ -1,9 +1,51 @@
 from rest_framework import serializers
-
 from django.contrib.auth.models import User
-
+from django.contrib.auth import authenticate
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username', 'first_name', 'last_name', 'email', 'is_staff')
+
+class AuthCustomTokenSerializer(serializers.Serializer):
+    """ Login by Username and Email"""
+    email_or_username = serializers.CharField()
+    password = serializers.CharField()
+
+    def validate(self, attrs):
+        # Ask for the request attributes
+        email_or_username = attrs.get('email_or_username')
+        password = attrs.get('password')
+
+        if email_or_username and password:
+
+            # Try to find the user with the request data
+            user_request = self.get_user_object(email_or_username)
+
+            if (not user_request):
+                raise serializers.ValidationError('Unable to login with the provided credentials')
+
+            username = user_request.username
+            user = authenticate(username=username, password=password)
+            if user:
+                if not user.is_active:
+                    raise serializers.ValidationError('User account is disabled')
+            else:
+                raise serializers.ValidationError('Unable to login with the provided credentials')
+        else:
+            raise serializers.ValidationError('Must include email_or_username and password')
+
+        attrs['user'] = user
+        return attrs
+
+    def get_user_object(self, username_or_email):
+        """ Return the user object by email or username"""
+        try:
+            user = User.objects.get(email=username_or_email)
+            return user
+        except User.DoesNotExist:
+            try:
+                user = User.objects.get(username=username_or_email)
+                return user
+            except User.DoesNotExist:
+                return None

--- a/decide/authentication/serializers.py
+++ b/decide/authentication/serializers.py
@@ -9,12 +9,12 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 class AuthCustomTokenSerializer(serializers.Serializer):
     """ Login by Username and Email"""
-    email_or_username = serializers.CharField()
+    username = serializers.CharField()
     password = serializers.CharField()
 
     def validate(self, attrs):
         # Ask for the request attributes
-        email_or_username = attrs.get('email_or_username')
+        email_or_username = attrs.get('username')
         password = attrs.get('password')
 
         if email_or_username and password:

--- a/decide/authentication/tests.py
+++ b/decide/authentication/tests.py
@@ -15,6 +15,7 @@ class AuthTestCase(APITestCase):
         mods.mock_query(self.client)
         u = User(username='voter1')
         u.set_password('123')
+        u.email = 'test@gmail.com'
         u.save()
 
     def tearDown(self):
@@ -28,8 +29,21 @@ class AuthTestCase(APITestCase):
         token = response.json()
         self.assertTrue(token.get('token'))
 
+    def test_login_email(self):
+        data = {'username': 'test@gmail.com', 'password': '123'}
+        response = self.client.post('/authentication/login/', data, format='json')
+        self.assertEqual(response.status_code, 200)
+
+        token = response.json()
+        self.assertTrue(token.get('token'))
+
     def test_login_fail(self):
         data = {'username': 'voter1', 'password': '321'}
+        response = self.client.post('/authentication/login/', data, format='json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_login_email_fail(self):
+        data = {'username': 'test@gmail.com', 'password': '321'}
         response = self.client.post('/authentication/login/', data, format='json')
         self.assertEqual(response.status_code, 400)
 

--- a/decide/authentication/urls.py
+++ b/decide/authentication/urls.py
@@ -1,11 +1,10 @@
-from django.urls import include, path
-from rest_framework.authtoken.views import obtain_auth_token
+from django.urls import path
 
-from .views import GetUserView, LogoutView
+from .views import GetUserView, LogoutView, LoginView
 
 
 urlpatterns = [
-    path('login/', obtain_auth_token),
+    path('login/', LoginView.as_view()),
     path('logout/', LogoutView.as_view()),
     path('getuser/', GetUserView.as_view()),
 ]

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -24,3 +24,11 @@ class LogoutView(APIView):
             pass
 
         return Response({})
+
+class LoginView(APIView):
+    def post(self, request):
+        serializer = AuthCustomTokenSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data['user']
+        token, created = Token.objects.get_or_create(user=user)
+        return Response({'token': token.key})

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -4,8 +4,7 @@ from rest_framework.authtoken.models import Token
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import ObjectDoesNotExist
 
-from .serializers import UserSerializer
-
+from .serializers import UserSerializer, AuthCustomTokenSerializer
 
 class GetUserView(APIView):
     def post(self, request):

--- a/decide/base/backends.py
+++ b/decide/base/backends.py
@@ -27,3 +27,11 @@ class AuthBackend(ModelBackend):
             request.session['auth-token'] = token['token']
 
         return u
+
+class EmailBackend(ModelBackend):
+
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        u = super().authenticate(request, username=username,
+                                 password=password, **kwargs)
+
+        return u

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -53,6 +53,7 @@ REST_FRAMEWORK = {
 }
 
 AUTHENTICATION_BACKENDS = [
+    'base.backends.EmailBackend',
     'base.backends.AuthBackend',
 ]
 


### PR DESCRIPTION
## Authentication Team
This Pull Request is related to the issue #5 to fix this problem I created a new serializer that checks the username input for username or emails, in order to authenticate the email I created a new backend auth and I included in the base of decide. Furthermore I created two test to validate that everything works correctly:
- Login the user with an email and correct password (positive test)
- Login the user with an email and incorrect password (negative test)

### REST
The url to login via email is: http://localhost:8000/authentication/login/
The input JSON should have the next structure:
`
{ username: test@gmail.com, password: 123 }
`